### PR TITLE
Add automatic versioning to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 # pyenv python configuration file
 .python-version
+
+# automatically generated version
+rt_factory/__rt_factory_version__.py

--- a/rt_factory/__init__.py
+++ b/rt_factory/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
+from .__rt_factory_version__ import version as rt_factory_version
 
 __author__ = """Peter Tillemans"""
 __email__ = 'pti@melexis.com'
-__version__ = '0.2.5'
+__version__ = rt_factory_version

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ test_requirements = [
 
 setup(
     name='rt_factory',
-    version='0.2.5',
+    use_scm_version = {
+        'write_to': 'rt_factory/__rt_factory_version__.py'
+    },
+    setup_requires=['setuptools_scm'],
     description="Pythonic wrapper for the artifactory API",
     long_description=readme + '\n\n' + history,
     author="Peter Tillemans",
@@ -40,7 +43,7 @@ setup(
     install_requires=requirements,
     license="Apache Software License 2.0",
     zip_safe=False,
-    keywords='rt_factory',
+    keywords=['Artifactory','rt_factory','wrapper'],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Changing and bumping version is old style. There is a bug that if you do
not have access to internet then scm tools kinda fail to provide version
during the run time (not case here), so it is safer to let them write
version to some file, which you then use to present as package version.

This looses any package runtime dependency to scmtools, as they are only
required during the packaging process.

Now you release by tagging (I think Travis-CI is already set for that).